### PR TITLE
[test] Fix missing ASL file script

### DIFF
--- a/asllib/tests/check-no-missing-file-in-run.sh
+++ b/asllib/tests/check-no-missing-file-in-run.sh
@@ -6,7 +6,7 @@ set -o nounset    # Exposes unset variables
 counter=0
 
 for d in "$1"/asllib/tests/*.t/; do
-  for f in $(git ls-tree --name-only HEAD "$d*.asl"); do
+  for f in $(git ls-files HEAD "$d*.asl"); do
     if ! grep -q "${f##*/}" "${d}run.t"; then
       echo "ASL file committed and not run: $f";
       counter=$counter+1;


### PR DESCRIPTION
At least my version of `git ls-tree` doesn't accept glob patterns (2.46.0), use `ls-files` instead.

Test by adding `echo $f` to show which files are checked. Also tested by adding a new ASL file to see if the script catches the error.